### PR TITLE
Fix missed SRID after copying a geometry in _handle_geom

### DIFF
--- a/djgeojson/serializers.py
+++ b/djgeojson/serializers.py
@@ -151,17 +151,19 @@ class Serializer(PythonSerializer):
         elif isinstance(value, dict) and 'type' in value:
             geometry = value
         else:
-            try:
-                # this will handle GEOSGeometry objects
-                # and string representations (e.g. ewkt, bwkt)
-                geometry = GEOSGeometry(value)
-            except ValueError:
-                # if the geometry couldn't be parsed.
-                # we can't generate valid geojson
-                error_msg = 'The field ["%s", "%s"] could not be parsed as a valid geometry' % (
-                    self.geometry_field, value
-                )
-                raise SerializationError(error_msg)
+            if isinstance(value, GEOSGeometry):
+                geometry = value
+            else:
+                try:
+                    # this will handle string representations (e.g. ewkt, bwkt)
+                    geometry = GEOSGeometry(value)
+                except ValueError:
+                    # if the geometry couldn't be parsed.
+                    # we can't generate valid geojson
+                    error_msg = 'The field ["%s", "%s"] could not be parsed as a valid geometry' % (
+                        self.geometry_field, value
+                    )
+                    raise SerializationError(error_msg)
 
             # Optional force 2D
             if self.options.get('force2d'):


### PR DESCRIPTION
In _handle_geom, take the value as the geometry in case it is an instance of GEOSGeometry, instead of creating from GEOSGeometry constructor. 
## Motivation

We use this tag in our template: {{ station_list|geojsonfeature:"position"|safe }}

It was working in our development environment, but in our production server we got this error:

> GEOSException: Calling transform() with no SRID set is not supported after using the templatetag 

In our the production server it creates a new geometry without SRID. It seems that is a problem of libgeos (development: libgeos-3.3.8; production: libgeos-3.2.0).
