### PR TITLE
Adds a warning for "Module version, as defined in PEP-0396"

### DIFF
--- a/djgeojson/__init__.py
+++ b/djgeojson/__init__.py
@@ -1,8 +1,11 @@
 #: Module version, as defined in PEP-0396.
 pkg_resources = __import__('pkg_resources')
-distribution = pkg_resources.get_distribution('django-geojson')
-
-__version__ = distribution.version
-
+try:
+    distribution = pkg_resources.get_distribution('django-geojson')
+    __version__ = distribution.version
+except:
+    __version__ = 'unknown'
+    import warnings
+    warnings.warn('No distribution found.')
 
 GEOJSON_DEFAULT_SRID = 4326


### PR DESCRIPTION
Hi,
I use your app as a git submodule, so it helps. I don't know if it's a good practice?

Thanks!
