### PR TITLE
Add an omit_model option to serializer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ Low-level serializer
 
     from djgeojson.serializers import Serializer as GeoJSONSerializer
 
-    GeoJSONSerializer().serialize(Restaurants.objects.all(), use_natural_keys=True)
+    GeoJSONSerializer().serialize(Restaurants.objects.all(), use_natural_keys=True, with_modelname=False)
 
 
 

--- a/djgeojson/serializers.py
+++ b/djgeojson/serializers.py
@@ -122,7 +122,8 @@ class Serializer(PythonSerializer):
                 self.handle_field(obj, field)
 
         # Add extra-info for deserializing
-        if hasattr(obj, '_meta'):
+        with_modelname = self.options.pop('with_modelname', True)
+        if hasattr(obj, '_meta') and with_modelname:
             self._current['properties']['model'] = smart_text(obj._meta)
 
         # If geometry not in model fields, may be a dynamic attribute
@@ -148,6 +149,7 @@ class Serializer(PythonSerializer):
         self.options.pop('simplify', None)
         self.options.pop('bbox', None)
         self.options.pop('bbox_auto', None)
+        self.options.pop('with_modelname', None)
 
         # Optional float precision control
         precision = self.options.pop('precision', None)

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -630,6 +630,29 @@ class ModelFieldTest(TestCase):
         self.assertEqual(objects[0].object.geom,
                          {'type': 'Point', 'coordinates': [0, 0]})
 
+    def test_model_can_be_omitted(self):
+        serializer = Serializer()
+        geojson = serializer.serialize(Address.objects.all(),
+                                       with_modelname=False)
+        features = json.loads(geojson)
+        self.assertEqual(
+            features, {
+                "crs": {
+                    "type": "link",
+                    "properties": {
+                        "href": "http://spatialreference.org/ref/epsg/4326/",
+                        "type": "proj4"
+                    }
+                },
+                u'type': u'FeatureCollection',
+                u'features': [{
+                    u'id': self.address.id,
+                    u'type': u'Feature',
+                    u'geometry': {u'type': u'Point', u'coordinates': [0, 0]},
+                    u'properties': {}
+                }]
+            })
+
 
 class GeoJSONValidatorTest(TestCase):
     def test_validator_raises_if_missing_type(self):


### PR DESCRIPTION
The GeoJSONSerializer always adds the model name from `_meta` if it's
present. It's not possible to ignore it by leaving it out of the
`properties` option. This PR adds an option `omit_model` that takes a boolean.
If set to `True` the model name does not appear in the GeoJSON.