### PR TITLE
Move Leaflet warning

### DIFF
--- a/djgeojson/fields.py
+++ b/djgeojson/fields.py
@@ -7,7 +7,6 @@ try:
     HAS_LEAFLET = True
 except:
     import warnings
-    warnings.warn('`django-leaflet` is not available.')
     HAS_LEAFLET = False
 try:
     from jsonfield.fields import JSONField, JSONFormField
@@ -44,7 +43,12 @@ class GeoJSONValidator(object):
 
 
 class GeoJSONFormField(JSONFormField):
-    widget = LeafletWidget if HAS_LEAFLET else HiddenInput
+    widget = None
+    if HAS_LEAFLET:
+        widget = LeafletWidget
+    else:
+        widget = HiddenInput
+        warnings.warn('`django-leaflet` is not available.')
 
     def __init__(self, *args, **kwargs):
         geom_type = kwargs.pop('geom_type')


### PR DESCRIPTION
Moved the Leaflet warning to inside of the `GeoJSONFormField` where the
Leaflet dependency is used. This prevents irrelevant warnings for users
that don't care about that functionality.