### PR TITLE
Support GeoJSON specification for named crs.

### DIFF
--- a/djgeojson/serializers.py
+++ b/djgeojson/serializers.py
@@ -79,16 +79,16 @@ class Serializer(PythonSerializer):
 
     def get_crs(self):
         crs = {}
-        type = self.options.pop('crs_type', None)
+        crs_type = self.options.pop('crs_type', None)
         properties = {}
-        if type == "name":
+        if crs_type == "name":
             # todo: GeoJSON Spec: OGC CRS URNs such as "urn:ogc:def:crs:OGC:1.3:CRS84" shall be preferred over legacy identifiers such as "EPSG:4326":
             properties["name"] = "EPSG:%s" % (str(self.srid))
         else:  # preserve default behaviour
-            type = "link"
+            crs_type = "link"
             properties["href"] = "http://spatialreference.org/ref/epsg/%s/" % (str(self.srid))
             properties["type"] = "proj4"
-        crs["type"] = type
+        crs["type"] = crs_type
         crs["properties"] = properties
         return crs
 

--- a/djgeojson/serializers.py
+++ b/djgeojson/serializers.py
@@ -79,10 +79,16 @@ class Serializer(PythonSerializer):
 
     def get_crs(self):
         crs = {}
-        crs["type"] = "link"
+        type = self.options.pop('crs_type', None)
         properties = {}
-        properties["href"] = "http://spatialreference.org/ref/epsg/%s/" % (str(self.srid))
-        properties["type"] = "proj4"
+        if type == "name":
+            # todo: GeoJSON Spec: OGC CRS URNs such as "urn:ogc:def:crs:OGC:1.3:CRS84" shall be preferred over legacy identifiers such as "EPSG:4326":
+            properties["name"] = "EPSG:%s" % (str(self.srid))
+        else:  # preserve default behaviour
+            type = "link"
+            properties["href"] = "http://spatialreference.org/ref/epsg/%s/" % (str(self.srid))
+            properties["type"] = "proj4"
+        crs["type"] = type
         crs["properties"] = properties
         return crs
 

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -168,6 +168,23 @@ class GeoJsonSerializerTest(TestCase):
         self.assertEqual(
             features2d, {"type": "FeatureCollection", "features": [{"geometry": {"type": "Point", "coordinates": [1.0, 2.0]}, "type": "Feature", "properties": {}}]})
 
+    def test_named_crs(self):
+        serializer = Serializer()
+        features = json.loads(serializer.serialize(
+            [{'geom': 'SRID=4326;POINT Z (1 2)'}],
+            crs_type="name"))
+        self.assertEqual(
+            features['crs'], {"type": "name", "properties": {"name": "EPSG:4326"}})
+
+    # todo: should misspelled name raise error instead?
+    def test_misspelled_named_crs(self):
+        serializer = Serializer()
+        features = json.loads(serializer.serialize(
+            [{'geom': 'SRID=4326;POINT Z (1 2)'}],
+            crs_type="named"))
+        self.assertEqual(
+            features['crs'], {"type": "link", "properties": {"href": "http://spatialreference.org/ref/epsg/4326/", "type": "proj4"}})
+
     def test_pk_property(self):
         route = Route.objects.create(name='red', geom="LINESTRING (0 0, 1 1)")
         serializer = Serializer()

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -171,16 +171,15 @@ class GeoJsonSerializerTest(TestCase):
     def test_named_crs(self):
         serializer = Serializer()
         features = json.loads(serializer.serialize(
-            [{'geom': 'SRID=4326;POINT Z (1 2)'}],
+            [{'geom': 'SRID=4326;POINT (1 2)'}],
             crs_type="name"))
         self.assertEqual(
             features['crs'], {"type": "name", "properties": {"name": "EPSG:4326"}})
 
-    # todo: should misspelled name raise error instead?
     def test_misspelled_named_crs(self):
         serializer = Serializer()
         features = json.loads(serializer.serialize(
-            [{'geom': 'SRID=4326;POINT Z (1 2)'}],
+            [{'geom': 'SRID=4326;POINT (1 2)'}],
             crs_type="named"))
         self.assertEqual(
             features['crs'], {"type": "link", "properties": {"href": "http://spatialreference.org/ref/epsg/4326/", "type": "proj4"}})


### PR DESCRIPTION
I wanted support for: http://geojson.org/geojson-spec.html#named-crs

Adds "crs_type" as an option to the serializer, with preserved default behaviour.