### PR TITLE
Adding support to kwargs URLs in TiledGeoJSONLayerView and support for Django 1.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - DJANGO_VERSION=1.4.10
   - DJANGO_VERSION=1.5.5
   - DJANGO_VERSION=1.6.1
+  - DJANGO_VERSION=1.7.1
 
 before_install:
  - sudo apt-get update > /dev/null

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -507,6 +507,24 @@ class TiledGeoJSONViewTest(TestCase):
         geojson = json.loads(smart_text(response.content))
         self.assertEqual(geojson['features'][0]['geometry']['coordinates'], [[0.0, 1.0], [10.0, 1.0]])
 
+    def test_view_with_kwargs_no_z(self):
+        self.view.kwargs = {'x': 8,
+                            'y': 7}
+
+        self.assertRaises(ValueError, self.view.render_to_response, **{"context": {}})
+
+    def test_view_with_kwargs_no_x(self):
+        self.view.kwargs = {'z': 8,
+                            'y': 7}
+
+        self.assertRaises(ValueError, self.view.render_to_response, **{"context": {}})
+
+    def test_view_with_kwargs_no_y(self):
+        self.view.kwargs = {'x': 8,
+                            'z': 7}
+
+        self.assertRaises(ValueError, self.view.render_to_response, **{"context": {}})
+
     def test_view_is_serialized_as_geojson(self):
         self.view.args = [4, 8, 7]
         response = self.view.render_to_response(context={})

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -1,6 +1,6 @@
 import json
 
-from django.test import TestCase, Client
+from django.test import TestCase
 from django.conf import settings
 from django.core import serializers
 from django.core.exceptions import ValidationError

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -499,16 +499,12 @@ class TiledGeoJSONViewTest(TestCase):
         self.r2 = Route.objects.create(geom=LineString((0, -1), (-10, -1)))
 
     def test_view_with_kwargs(self):
-
-        """Testing on issue #42"""
-
         self.view.kwargs = {'z': 4,
                             'x': 8,
                             'y': 7}
         response = self.view.render_to_response(context={})
         geojson = json.loads(smart_text(response.content))
         self.assertEqual(geojson['features'][0]['geometry']['coordinates'], [[0.0, 1.0], [10.0, 1.0]])
-
 
     def test_view_is_serialized_as_geojson(self):
         self.view.args = [4, 8, 7]

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -507,23 +507,44 @@ class TiledGeoJSONViewTest(TestCase):
         geojson = json.loads(smart_text(response.content))
         self.assertEqual(geojson['features'][0]['geometry']['coordinates'], [[0.0, 1.0], [10.0, 1.0]])
 
+    def test_view_with_kwargs_wrong_type_z(self):
+        self.view.kwargs = {'z': 'a',
+                            'x': 8,
+                            'y': 7}
+
+        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+
+    def test_view_with_kwargs_wrong_type_x(self):
+        self.view.kwargs = {'z': 1,
+                            'x': 'a',
+                            'y': 7}
+
+        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+
+    def test_view_with_kwargs_wrong_type_y(self):
+        self.view.kwargs = {'z': 4,
+                            'x': 8,
+                            'y': 'a'}
+
+        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+
     def test_view_with_kwargs_no_z(self):
         self.view.kwargs = {'x': 8,
                             'y': 7}
 
-        self.assertRaises(ValueError, self.view.render_to_response, **{"context": {}})
+        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
 
     def test_view_with_kwargs_no_x(self):
         self.view.kwargs = {'z': 8,
                             'y': 7}
 
-        self.assertRaises(ValueError, self.view.render_to_response, **{"context": {}})
+        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
 
     def test_view_with_kwargs_no_y(self):
         self.view.kwargs = {'x': 8,
                             'z': 7}
 
-        self.assertRaises(ValueError, self.view.render_to_response, **{"context": {}})
+        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
 
     def test_view_is_serialized_as_geojson(self):
         self.view.args = [4, 8, 7]

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -1,4 +1,5 @@
 import json
+from django.http import HttpResponseBadRequest
 
 from django.test import TestCase
 from django.conf import settings
@@ -511,40 +512,51 @@ class TiledGeoJSONViewTest(TestCase):
         self.view.kwargs = {'z': 'a',
                             'x': 8,
                             'y': 7}
-
-        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+        response = self.view.render_to_response(context={})
+        self.assertTrue(type(response) is HttpResponseBadRequest)
+        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_wrong_type_x(self):
         self.view.kwargs = {'z': 1,
                             'x': 'a',
                             'y': 7}
 
-        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+        response = self.view.render_to_response(context={})
+        self.assertTrue(type(response) is HttpResponseBadRequest)
+        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_wrong_type_y(self):
         self.view.kwargs = {'z': 4,
                             'x': 8,
                             'y': 'a'}
 
-        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+        response = self.view.render_to_response(context={})
+        self.assertTrue(type(response) is HttpResponseBadRequest)
+        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_no_z(self):
         self.view.kwargs = {'x': 8,
                             'y': 7}
 
-        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+        response = self.view.render_to_response(context={})
+        self.assertTrue(type(response) is HttpResponseBadRequest)
+        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_no_x(self):
         self.view.kwargs = {'z': 8,
                             'y': 7}
 
-        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+        response = self.view.render_to_response(context={})
+        self.assertTrue(type(response) is HttpResponseBadRequest)
+        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_no_y(self):
         self.view.kwargs = {'x': 8,
                             'z': 7}
 
-        self.assertRaises(ValueError, self.view.render_to_response, **{'context': {}})
+        response = self.view.render_to_response(context={})
+        self.assertTrue(type(response) is HttpResponseBadRequest)
+        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_is_serialized_as_geojson(self):
         self.view.args = [4, 8, 7]

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -514,7 +514,6 @@ class TiledGeoJSONViewTest(TestCase):
                             'y': 7}
         response = self.view.render_to_response(context={})
         self.assertTrue(type(response) is HttpResponseBadRequest)
-        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_wrong_type_x(self):
         self.view.kwargs = {'z': 1,
@@ -523,7 +522,6 @@ class TiledGeoJSONViewTest(TestCase):
 
         response = self.view.render_to_response(context={})
         self.assertTrue(type(response) is HttpResponseBadRequest)
-        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_wrong_type_y(self):
         self.view.kwargs = {'z': 4,
@@ -532,7 +530,6 @@ class TiledGeoJSONViewTest(TestCase):
 
         response = self.view.render_to_response(context={})
         self.assertTrue(type(response) is HttpResponseBadRequest)
-        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_no_z(self):
         self.view.kwargs = {'x': 8,
@@ -540,7 +537,6 @@ class TiledGeoJSONViewTest(TestCase):
 
         response = self.view.render_to_response(context={})
         self.assertTrue(type(response) is HttpResponseBadRequest)
-        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_no_x(self):
         self.view.kwargs = {'z': 8,
@@ -548,7 +544,6 @@ class TiledGeoJSONViewTest(TestCase):
 
         response = self.view.render_to_response(context={})
         self.assertTrue(type(response) is HttpResponseBadRequest)
-        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_with_kwargs_no_y(self):
         self.view.kwargs = {'x': 8,
@@ -556,7 +551,6 @@ class TiledGeoJSONViewTest(TestCase):
 
         response = self.view.render_to_response(context={})
         self.assertTrue(type(response) is HttpResponseBadRequest)
-        self.assertTrue(response.content == u"View parameters could not be processed.")
 
     def test_view_is_serialized_as_geojson(self):
         self.view.args = [4, 8, 7]

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -451,6 +451,7 @@ class GeoJsonTemplateTagTest(TestCase):
     def test_geom_field_raises_attributeerror_if_unknown(self):
         self.assertRaises(AttributeError, geojsonfeature, self.route1, ":geo")
 
+
 class ViewsTest(TestCase):
 
     def setUp(self):

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -1,6 +1,6 @@
 import json
 
-from django.test import TestCase
+from django.test import TestCase, Client
 from django.conf import settings
 from django.core import serializers
 from django.core.exceptions import ValidationError
@@ -451,7 +451,6 @@ class GeoJsonTemplateTagTest(TestCase):
     def test_geom_field_raises_attributeerror_if_unknown(self):
         self.assertRaises(AttributeError, geojsonfeature, self.route1, ":geo")
 
-
 class ViewsTest(TestCase):
 
     def setUp(self):
@@ -498,6 +497,18 @@ class TiledGeoJSONViewTest(TestCase):
         self.view = TiledGeoJSONLayerView(model=Route)
         self.r1 = Route.objects.create(geom=LineString((0, 1), (10, 1)))
         self.r2 = Route.objects.create(geom=LineString((0, -1), (-10, -1)))
+
+    def test_view_with_kwargs(self):
+
+        """Testing on issue #42"""
+
+        self.view.kwargs = {'z': 4,
+                            'x': 8,
+                            'y': 7}
+        response = self.view.render_to_response(context={})
+        geojson = json.loads(smart_text(response.content))
+        self.assertEqual(geojson['features'][0]['geometry']['coordinates'], [[0.0, 1.0], [10.0, 1.0]])
+
 
     def test_view_is_serialized_as_geojson(self):
         self.view.args = [4, 8, 7]

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -99,7 +99,7 @@ class TiledGeoJSONLayerView(GeoJSONLayerView):
                 self.x = int(self.kwargs.get('x'))
                 self.y = int(self.kwargs.get('y'))
             except (ValueError, TypeError):
-                return HttpResponseBadRequest(u"View parameters could not be processed. Check your URLconf.")
+                return HttpResponseBadRequest(u"View parameters could not be processed.")
 
         nw = self.tile_coord(self.x, self.y, self.z)
         se = self.tile_coord(self.x + 1, self.y + 1, self.z)

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -41,6 +41,10 @@ class GeoJSONResponseMixin(object):
         serializer = GeoJSONSerializer()
         response = self.response_class(**response_kwargs)
         queryset = self.get_queryset()
+
+        if type(queryset) is HttpResponseBadRequest:
+            return queryset
+
         options = dict(properties=self.properties,
                        precision=self.precision,
                        simplify=self.simplify,
@@ -95,10 +99,11 @@ class TiledGeoJSONLayerView(GeoJSONLayerView):
             # let's try to get these as kwargs
 
             try:
-                self.z = int(self.kwargs.get('z'))
-                self.x = int(self.kwargs.get('x'))
-                self.y = int(self.kwargs.get('y'))
-            except (ValueError, TypeError):
+
+                self.z = int(self.kwargs['z'])
+                self.x = int(self.kwargs['x'])
+                self.y = int(self.kwargs['y'])
+            except (ValueError, TypeError, KeyError):
                 return HttpResponseBadRequest(u"View parameters could not be processed.")
 
         nw = self.tile_coord(self.x, self.y, self.z)

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -1,4 +1,5 @@
 import math
+from django.http import HttpResponseBadRequest
 
 from django.views.generic import ListView
 from django.utils.decorators import method_decorator
@@ -93,26 +94,12 @@ class TiledGeoJSONLayerView(GeoJSONLayerView):
         except AttributeError:
             # let's try to get these as kwargs
 
-            self.z = self.kwargs.get('z', None)
-            self.x = self.kwargs.get('x', None)
-            self.y = self.kwargs.get('y', None)
-
-            if self.z is None:
-                raise ValueError('View parameter Z not provided in URL.')
-
-            if self.x is None:
-                raise ValueError('View parameter X not provided in URL.')
-
-            if self.y is None:
-                raise ValueError('View parameter Y not provided in URL.')
-
             try:
-                self.z = int(self.z)
-                self.x = int(self.x)
-                self.y = int(self.y)
-            except ValueError:
-                # should we just reraise this?
-                raise ValueError('The values for view parameters Z, X or Y are not valid integers.')
+                self.z = int(self.kwargs.get('z'))
+                self.x = int(self.kwargs.get('x'))
+                self.y = int(self.kwargs.get('y'))
+            except (ValueError, TypeError):
+                return HttpResponseBadRequest(u"View parameters could not be processed. Check your URLconf.")
 
         nw = self.tile_coord(self.x, self.y, self.z)
         se = self.tile_coord(self.x + 1, self.y + 1, self.z)

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -88,7 +88,23 @@ class TiledGeoJSONLayerView(GeoJSONLayerView):
         """
         Inspired by Glen Roberton's django-geojson-tiles view
         """
-        self.z, self.x, self.y = map(int, self.args[:3])
+        try:
+            self.z, self.x, self.y = map(int, self.args[:3])
+        except AttributeError:
+            # let's try to get these as kwargs
+            self.z = self.kwargs.get("z", None)
+            self.x = self.kwargs.get("x", None)
+            self.y = self.kwargs.get("y", None)
+
+            if not self.z:
+                raise ValueError("View parameter Z not provided in URL.")
+
+            if not self.x:
+                raise ValueError("View parameter X not provided in URL.")
+
+            if not self.y:
+                raise ValueError("View parameter Y not provided in URL.")
+
         nw = self.tile_coord(self.x, self.y, self.z)
         se = self.tile_coord(self.x + 1, self.y + 1, self.z)
         bbox = Polygon((nw, (se[0], nw[1]),

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -92,18 +92,27 @@ class TiledGeoJSONLayerView(GeoJSONLayerView):
             self.z, self.x, self.y = map(int, self.args[:3])
         except AttributeError:
             # let's try to get these as kwargs
-            self.z = self.kwargs.get("z", None)
-            self.x = self.kwargs.get("x", None)
-            self.y = self.kwargs.get("y", None)
 
-            if not self.z:
-                raise ValueError("View parameter Z not provided in URL.")
+            self.z = self.kwargs.get('z', None)
+            self.x = self.kwargs.get('x', None)
+            self.y = self.kwargs.get('y', None)
 
-            if not self.x:
-                raise ValueError("View parameter X not provided in URL.")
+            if self.z is None:
+                raise ValueError('View parameter Z not provided in URL.')
 
-            if not self.y:
-                raise ValueError("View parameter Y not provided in URL.")
+            if self.x is None:
+                raise ValueError('View parameter X not provided in URL.')
+
+            if self.y is None:
+                raise ValueError('View parameter Y not provided in URL.')
+
+            try:
+                self.z = int(self.z)
+                self.x = int(self.x)
+                self.y = int(self.y)
+            except ValueError:
+                # should we just reraise this?
+                raise ValueError('The values for view parameters Z, X or Y are not valid integers.')
 
         nw = self.tile_coord(self.x, self.y, self.z)
         se = self.tile_coord(self.x + 1, self.y + 1, self.z)

--- a/quicktest.py
+++ b/quicktest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import argparse
+import django
 from django.conf import settings
 
 
@@ -45,14 +46,16 @@ class QuickDjangoTest(object):
             INSTALLED_APPS=self.INSTALLED_APPS + self.apps,
         )
 
-        from django.test.simple import DjangoTestSuiteRunner
-
-        import django
-
-        if hasattr(django, "setup"):
+        if django.VERSION >= (1, 7, 0):
+            # see: https://docs.djangoproject.com/en/dev/releases/1.7/#standalone-scripts
             django.setup()
+        if django.VERSION >= (1, 6, 0):
+            # see: https://docs.djangoproject.com/en/dev/releases/1.6/#discovery-of-tests-in-any-test-module
+            from django.test.runner import DiscoverRunner as Runner
+        else:
+            from django.test.simple import DjangoTestSuiteRunner as Runner
 
-        failures = DjangoTestSuiteRunner().run_tests(self.apps, verbosity=1)
+        failures = Runner().run_tests(self.apps, verbosity=1)
         if failures:  # pragma: no cover
             sys.exit(failures)
 

--- a/quicktest.py
+++ b/quicktest.py
@@ -44,7 +44,14 @@ class QuickDjangoTest(object):
             },
             INSTALLED_APPS=self.INSTALLED_APPS + self.apps,
         )
+
         from django.test.simple import DjangoTestSuiteRunner
+
+        import django
+
+        if hasattr(django, "setup"):
+            django.setup()
+
         failures = DjangoTestSuiteRunner().run_tests(self.apps, verbosity=1)
         if failures:  # pragma: no cover
             sys.exit(failures)


### PR DESCRIPTION
This PR addresses two issues:

* Support for using kwargs in URL's, as noted on bug #42;
* Upgrading quicktest to support Django 1.7 test system, including a call on django.setup();

These are simple changes and there is a test for #42. Instead of setting everything up with args, I reused the data provided in other tests and configured kwargs instead of args. It now can handle both args and kwargs, provided that args come up empty or with AttributeError. Do you guys see any other exceptions that might be thrown inside the map call on line 92 (92 on this PR).?