### PR TITLE
used HAS_GEOS from django.contrib.gis.geos to check before importing

### DIFF
--- a/djgeojson/serializers.py
+++ b/djgeojson/serializers.py
@@ -24,20 +24,16 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.core.serializers.base import SerializationError, DeserializationError
 from django.utils.encoding import smart_text
 
-
 try:
+    from django.contrib.gis.geos.libgeos import geos_version_info
+    geos_version_info()
+
     from django.contrib.gis.geos import WKBWriter
-except ImportError:
-    from .nogeos import WKBWriter
-
-try:
     from django.contrib.gis.geos import GEOSGeometry
-except ImportError:
-    from .nogeos import GEOSGeometry
-
-try:
     from django.contrib.gis.db.models.fields import GeometryField
 except ImportError:
+    from .nogeos import WKBWriter
+    from .nogeos import GEOSGeometry
     from .fields import GeometryField
 
 from . import GEOJSON_DEFAULT_SRID

--- a/djgeojson/templatetags/geojson_tags.py
+++ b/djgeojson/templatetags/geojson_tags.py
@@ -4,14 +4,15 @@ import re
 from six import string_types
 
 from django import template
-try:
-    from django.contrib.gis.geos import GEOSGeometry
-except ImportError:
-    from ..nogeos import GEOSGeometry
 
 try:
+    from django.contrib.gis.geos.libgeos import geos_version_info
+    geos_version_info()
+
+    from django.contrib.gis.geos import GEOSGeometry
     from django.contrib.gis.db.models.fields import GeometryField
-except ImportError:
+except:
+    from ..nogeos import GEOSGeometry
     from ..fields import GeometryField
 
 from .. import GEOJSON_DEFAULT_SRID


### PR DESCRIPTION
Looks like commit [d2bcb05](https://github.com/django/django/commit/d2bcb0598058dd93eac94bdbb7dd2565cff0abea) broke the exception handling that allowed django-geojson to fallback on nogeos. Using HAS_GEOS resolves this by checking to see if GEOS is installed before trying to import it.