### PR TITLE
Reformatted import checking and added import check to view.py

### DIFF
--- a/djgeojson/nogeos.py
+++ b/djgeojson/nogeos.py
@@ -12,5 +12,9 @@ class GEOSGeometry(object):
         return
 
 
+class Polygon(GEOSGeometry):
+    pass
+
+
 class WKBWriter(object):
     pass

--- a/djgeojson/serializers.py
+++ b/djgeojson/serializers.py
@@ -23,15 +23,13 @@ from django.core.serializers.python import (_get_model,
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.serializers.base import SerializationError, DeserializationError
 from django.utils.encoding import smart_text
+from django.core.exceptions import ImproperlyConfigured
 
 try:
-    from django.contrib.gis.geos.libgeos import geos_version_info
-    geos_version_info()
-
     from django.contrib.gis.geos import WKBWriter
     from django.contrib.gis.geos import GEOSGeometry
     from django.contrib.gis.db.models.fields import GeometryField
-except ImportError:
+except (ImportError, ImproperlyConfigured):
     from .nogeos import WKBWriter
     from .nogeos import GEOSGeometry
     from .fields import GeometryField

--- a/djgeojson/templatetags/geojson_tags.py
+++ b/djgeojson/templatetags/geojson_tags.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 try:
     from django.contrib.gis.geos import GEOSGeometry
     from django.contrib.gis.db.models.fields import GeometryField
-except(ImportError, ImproperlyConfigured):
+except (ImportError, ImproperlyConfigured):
     from ..nogeos import GEOSGeometry
     from ..fields import GeometryField
 

--- a/djgeojson/templatetags/geojson_tags.py
+++ b/djgeojson/templatetags/geojson_tags.py
@@ -4,14 +4,12 @@ import re
 from six import string_types
 
 from django import template
+from django.core.exceptions import ImproperlyConfigured
 
 try:
-    from django.contrib.gis.geos.libgeos import geos_version_info
-    geos_version_info()
-
     from django.contrib.gis.geos import GEOSGeometry
     from django.contrib.gis.db.models.fields import GeometryField
-except:
+except(ImportError, ImproperlyConfigured):
     from ..nogeos import GEOSGeometry
     from ..fields import GeometryField
 

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -3,9 +3,15 @@ import math
 from django.views.generic import ListView
 from django.utils.decorators import method_decorator
 from django.views.decorators.gzip import gzip_page
-from django.contrib.gis.geos.geometry import Polygon
-from django.contrib.gis.db.models import PointField
 from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import ImproperlyConfigured
+
+try:
+    from django.contrib.gis.geos.geometry import Polygon
+    from django.contrib.gis.db.models import PointField
+except (ImportError, ImproperlyConfigured):
+    from .fields import PointField
+    from .nogeos import Polygon
 
 from .http import HttpJSONResponse
 from .serializers import Serializer as GeoJSONSerializer


### PR DESCRIPTION
While looking over django-leaflet I discovered why I was having trouble using the ImproperlyConfigured exception and updated the code to catch it . Also, view.py was still giving errors without GEOS installed and that should be fixed now.