### PR TITLE
handle natural keys in views

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Options are :
 * **srid** : projection (*default*: 4326, for WGS84)
 * **bbox** : Allows you to set your own bounding box on feature collection level
 * **bbox_auto** : True/False (default false). Will automatically generate a bounding box on a per feature level.
-
+* **use_natural_keys** : serialize natural keys instead of primary keys (*default*: ``False``)
 
 
 Tiled GeoJSON layer view

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -46,6 +46,8 @@ class GeoJSONResponseMixin(object):
     """ bbox auto """
     bbox_auto = False
 
+    use_natural_keys = False
+
     def render_to_response(self, context, **response_kwargs):
         """
         Returns a JSON response, transforming 'context' to make the payload.
@@ -61,7 +63,8 @@ class GeoJSONResponseMixin(object):
                        geometry_field=self.geometry_field,
                        force2d=self.force2d,
                        bbox=self.bbox,
-                       bbox_auto=self.bbox_auto)
+                       bbox_auto=self.bbox_auto,
+                       use_natural_keys=self.use_natural_keys)
         serializer.serialize(queryset, stream=response, ensure_ascii=False,
                              **options)
         return response


### PR DESCRIPTION
The serializer supports use_natural_keys, but the view implementation was missing this feature