### PR TITLE
Integrate jsonfield_compat

### DIFF
--- a/djgeojson/fields.py
+++ b/djgeojson/fields.py
@@ -12,11 +12,11 @@ except:
     warnings.warn('`django-leaflet` is not available.')
     HAS_LEAFLET = False
 try:
-    from jsonfield.fields import JSONField, JSONFormField
+    from jsonfield_compat.fields import JSONField, JSONFormField
 except ImportError:
     class Missing(object):
         def __init__(self, *args, **kwargs):
-            err_msg = '`jsonfield` dependency missing. See README.'
+            err_msg = '`jsonfield-compat` dependency missing. See README.'
             raise ImproperlyConfigured(err_msg)
 
     JSONField = Missing

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'six',
     ],
     extras_require={
-        'field': ['jsonfield', 'django-leaflet>=0.12'],
+        'field': ['django-jsonfield-compat', 'django-leaflet>=0.12'],
     },
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This integrates [django-jsonfield-compat](https://github.com/kbussell/django-jsonfield-compat), which is an adapter layer between django-jsonfield and Django 1.9's native JSONField implementation.

Please consider merging. Happy to answer any questions.