### PR TITLE
Fix encoding error in setup.py; Fix #83 and Fix #53

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     download_url="http://pypi.python.org/pypi/django-geojson/",
     description="Serve vectorial map layers with Django",
     long_description=open(os.path.join(here, 'README.rst')).read() + '\n\n' +
-                     open(os.path.join(here, 'CHANGES')).read(),
+                     open(os.path.join(here, 'CHANGES'), encoding='utf-8').read(),
     license='LPGL, see LICENSE file.',
     install_requires=[
         'Django',


### PR DESCRIPTION
While `pip install django-geojson` works properly on my machine, but it suddenly fails when run inside of a docker container with the same ubuntu version. 

Minimal Dockerfile for reference:

```
FROM ubuntu:17.04
RUN apt-get update
RUN apt-get install -y python3-pip
RUN pip3 install django-geojson
```