### PR TITLE
Use proper media type for GeoJSON

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ CHANGELOG
 2.12.0 (unreleased)
 ===================
 
--
+- Change media type to 'application/geo+json'
 
 2.11.0 (2017-12-05)
 ===================

--- a/djgeojson/http.py
+++ b/djgeojson/http.py
@@ -1,7 +1,15 @@
+import warnings
 from django.http import HttpResponse
 
 
-class HttpJSONResponse(HttpResponse):
+class HttpGeoJSONResponse(HttpResponse):
     def __init__(self, **kwargs):
-        kwargs['content_type'] = 'application/json'
+        kwargs['content_type'] = 'application/geo+json'
+        super(HttpGeoJSONResponse, self).__init__(**kwargs)
+
+
+class HttpJSONResponse(HttpGeoJSONResponse):
+    def __init__(self, **kwargs):
+        warnings.warn("The 'HttpJSONResponse' class was renamed to 'HttpGeoJSONResponse'",
+                      DeprecationWarning)
         super(HttpJSONResponse, self).__init__(**kwargs)

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -25,7 +25,7 @@ try:
 except (ImportError, ImproperlyConfigured):
     from .fields import PointField
 
-from .http import HttpJSONResponse
+from .http import HttpGeoJSONResponse
 from .serializers import Serializer as GeoJSONSerializer
 from . import GEOJSON_DEFAULT_SRID
 
@@ -34,7 +34,7 @@ class GeoJSONResponseMixin(object):
     """
     A mixin that can be used to render a GeoJSON response.
     """
-    response_class = HttpJSONResponse
+    response_class = HttpGeoJSONResponse
     """ Select fields for properties """
     properties = []
     """ Limit float precision """


### PR DESCRIPTION
[RFC 7946: The GeoJSON Format (section 12)](https://tools.ietf.org/html/rfc7946#section-12):

>  **The media type for GeoJSON text is "application/geo+json"** and is
>    registered in the "Media Types" registry described in [RFC6838].  The
>    entry for "application/vnd.geo+json" in the same registry should have
>    its status changed to be "OBSOLETED" with a pointer to the media type
>    "application/geo+json" and a reference added to this RFC.
> ...
>    Applications that use this media type:  No known applications
>       currently use this media type.  **This media type is intended for
>       GeoJSON applications currently using the "application/
>       vnd.geo+json" or "application/json" media types**, of which there
>       are several categories: web mapping, geospatial databases,
>       geographic data processing APIs, data analysis and storage
>       services, and data dissemination.