### PR TITLE
Add support for crs_type using the view options

### DIFF
--- a/djgeojson/serializers.py
+++ b/djgeojson/serializers.py
@@ -460,6 +460,7 @@ class Serializer(PythonSerializer):
         self.bbox_auto = options.get("bbox_auto", None)
         self.srid = options.get("srid", GEOJSON_DEFAULT_SRID)
         self.crs = options.get("crs", True)
+        self.crs_type = options.get("crs_type", 'name')
 
         self.start_serialization()
 

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -57,6 +57,8 @@ class GeoJSONResponseMixin(object):
 
     with_modelname = True
 
+    crs_type = 'name'
+
     def render_to_response(self, context, **response_kwargs):
         """
         Returns a JSON response, transforming 'context' to make the payload.

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -74,7 +74,8 @@ class GeoJSONResponseMixin(object):
                        bbox=self.bbox,
                        bbox_auto=self.bbox_auto,
                        use_natural_keys=self.use_natural_keys,
-                       with_modelname=self.with_modelname)
+                       with_modelname=self.with_modelname,
+                       crs_type=self.crs_type)
         serializer.serialize(queryset, stream=response, ensure_ascii=False,
                              **options)
         return response

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -57,7 +57,7 @@ Options are :
 * **bbox_auto** : True/False (default false). Will automatically generate a bounding box on a per feature level.
 * **use_natural_keys** : serialize natural keys instead of primary keys (*default*: ``False``)
 * **with_modelname** : add the app and model name to the properties. (*default*: ``True``)
-
+* **crs_type** : add the type of crs generated, options: ``name``  and ``link`` (*default*: ``name``)
 
 Tiled GeoJSON layer view
 ------------------------


### PR DESCRIPTION
By default the GeoJson generated contains a link type CRS. This doesn't work well with for example openlayers. The code for generating the named CRS was implemented but not configurable via the options. This solution fixes this issue.