### PR TITLE
Upgrade tested Python and Django versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,54 +1,43 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Python application
 
 on: [push, pull_request]
 
 jobs:
   tests_python:
-    name: Test on Python ${{ matrix.python_version }} and Django ${{ matrix.django_version }}
+    name: Test on Python ${{ matrix.python_version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django_version: [ '3.2', '4.0', '4.1' ]
-        python_version: [ '3.7', '3.8', '3.9', '3.10' ]
-        exclude:
-
-          - django_version: '4.0'
-            python_version: '3.7'
-
-          - django_version: '4.1'
-            python_version: '3.7'
+        python_version:
+        - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - '3.12'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python_version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python_version }}
+
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ matrix.django_version }}
+        key: ${{ runner.os }}-pip-${{ matrix.python_version }}
+
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y libproj-dev libgeos-dev gdal-bin libgdal-dev libsqlite3-mod-spatialite
         python -m pip install --upgrade pip
-        pip install -U flake8 coveralls argparse
-        pip install -U Django~=${{ matrix.django_version }}
-    - name: Lint with flake8
-      run: |
-        flake8 --ignore=E501,W504 djgeojson
-    - name: Test Django
-      run: |
-        python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run ./quicktest.py djgeojson
-    - name: Coverage
-      if: ${{ success() }}
-      run: |
-        coveralls --service=github
+        python -m pip install --upgrade 'tox>=4.0.0rc3'
+
+    - name: Run tox targets for ${{ matrix.python_version }}
+      run: tox run -f py$(echo ${{ matrix.python_version }} | tr -d .)

--- a/djgeojson/__init__.py
+++ b/djgeojson/__init__.py
@@ -1,13 +1,1 @@
-#: Module version, as defined in PEP-0396.
-from pkg_resources import DistributionNotFound
-
-pkg_resources = __import__('pkg_resources')
-try:
-    distribution = pkg_resources.get_distribution('django-geojson')
-    __version__ = distribution.version
-except (AttributeError, DistributionNotFound):
-    __version__ = 'unknown'
-    import warnings
-    warnings.warn('No distribution found.')
-
 GEOJSON_DEFAULT_SRID = 4326

--- a/djgeojson/fields.py
+++ b/djgeojson/fields.py
@@ -1,9 +1,10 @@
 from __future__ import unicode_literals
 
-from django.db.models import JSONField
-from django.forms.fields import JSONField as JSONFormField, InvalidJSONInput
-from django.forms.widgets import HiddenInput
 from django.core.exceptions import ValidationError
+from django.db.models import JSONField
+from django.forms.fields import InvalidJSONInput
+from django.forms.fields import JSONField as JSONFormField
+from django.forms.widgets import HiddenInput
 from django.utils.translation import gettext_lazy as _
 
 try:

--- a/djgeojson/http.py
+++ b/djgeojson/http.py
@@ -1,4 +1,5 @@
 import warnings
+
 from django.http import HttpResponse
 
 

--- a/djgeojson/serializers.py
+++ b/djgeojson/serializers.py
@@ -7,9 +7,8 @@
 """
 import json
 import logging
-from io import StringIO  # NOQA
-
 from contextlib import contextmanager
+from io import StringIO  # NOQA
 
 import django
 from django.db.models.base import Model
@@ -20,19 +19,21 @@ except ImportError:
     from django.db.models.query import QuerySet
     ValuesQuerySet = None
 
-from django.forms.models import model_to_dict
-from django.core.serializers.python import (_get_model,
-                                            Serializer as PythonSerializer,
-                                            Deserializer as PythonDeserializer)
-from django.core.serializers.json import DjangoJSONEncoder
-from django.core.serializers.base import SerializationError, DeserializationError
-from django.utils.encoding import smart_str
 from django.core.exceptions import ImproperlyConfigured
+from django.core.serializers.base import (
+    DeserializationError,
+    SerializationError,
+)
+from django.core.serializers.json import DjangoJSONEncoder
+from django.core.serializers.python import Deserializer as PythonDeserializer
+from django.core.serializers.python import Serializer as PythonSerializer
+from django.core.serializers.python import _get_model
+from django.forms.models import model_to_dict
+from django.utils.encoding import smart_str
 
 try:
-    from django.contrib.gis.geos import WKBWriter
-    from django.contrib.gis.geos import GEOSGeometry
     from django.contrib.gis.db.models.fields import GeometryField
+    from django.contrib.gis.geos import GEOSGeometry, WKBWriter
 except (ImportError, ImproperlyConfigured):
     from .nogeos import WKBWriter
     from .nogeos import GEOSGeometry
@@ -40,7 +41,6 @@ except (ImportError, ImproperlyConfigured):
 
 from . import GEOJSON_DEFAULT_SRID
 from .fields import GeoJSONField
-
 
 logger = logging.getLogger(__name__)
 

--- a/djgeojson/templatetags/geojson_tags.py
+++ b/djgeojson/templatetags/geojson_tags.py
@@ -5,15 +5,14 @@ from django import template
 from django.core.exceptions import ImproperlyConfigured
 
 try:
-    from django.contrib.gis.geos import GEOSGeometry
     from django.contrib.gis.db.models.fields import GeometryField
+    from django.contrib.gis.geos import GEOSGeometry
 except (ImportError, ImproperlyConfigured):
     from ..nogeos import GEOSGeometry
     from ..fields import GeometryField
 
 from .. import GEOJSON_DEFAULT_SRID
-from ..serializers import Serializer, DjangoGeoJSONEncoder
-
+from ..serializers import DjangoGeoJSONEncoder, Serializer
 
 register = template.Library()
 

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -3,20 +3,19 @@ from __future__ import unicode_literals
 import json
 
 import django
+from django.conf import settings
+from django.contrib.gis.db import models
+from django.contrib.gis.geos import GeometryCollection, LineString, Point
+from django.core import serializers
+from django.core.exceptions import SuspiciousOperation, ValidationError
 from django.forms import HiddenInput
 from django.test import TestCase
-from django.conf import settings
-from django.core import serializers
-from django.core.exceptions import ValidationError, SuspiciousOperation
-from django.contrib.gis.db import models
-from django.contrib.gis.geos import LineString, Point, GeometryCollection
 from django.utils.encoding import smart_str
 
-from .templatetags.geojson_tags import geojsonfeature
-from .serializers import Serializer
-from .views import GeoJSONLayerView, TiledGeoJSONLayerView
 from .fields import GeoJSONField, GeoJSONFormField, GeoJSONValidator
-
+from .serializers import Serializer
+from .templatetags.geojson_tags import geojsonfeature
+from .views import GeoJSONLayerView, TiledGeoJSONLayerView
 
 settings.SERIALIZATION_MODULES = {'geojson': 'djgeojson.serializers'}
 
@@ -680,9 +679,9 @@ class TiledGeoJSONViewFixedSridTest(TestCase):
         response = self.view.render_to_response(context={})
         geojson = json.loads(smart_str(response.content))
         self.assertEqual(len(geojson['features']), 2)
-        self.assertAlmostEqual(geojson['features'][0]['geometry']['coordinates'][0], 6.843322039261242)
+        self.assertAlmostEqual(geojson['features'][0]['geometry']['coordinates'][0], 6.843321961076886)
         self.assertAlmostEqual(geojson['features'][0]['geometry']['coordinates'][1], 52.76181518632031)
-        self.assertAlmostEqual(geojson['features'][1]['geometry']['coordinates'][0], 6.846053318324978)
+        self.assertAlmostEqual(geojson['features'][1]['geometry']['coordinates'][0], 6.846053240233331)
         self.assertAlmostEqual(geojson['features'][1]['geometry']['coordinates'][1], 52.77442791046052)
 
 

--- a/djgeojson/views.py
+++ b/djgeojson/views.py
@@ -7,11 +7,10 @@ try:
     from django.contrib.gis.db.models.functions import Intersection
 except (ImportError, ImproperlyConfigured):
     Intersection = None
-from django.views.generic import ListView
+from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.utils.decorators import method_decorator
 from django.views.decorators.gzip import gzip_page
-from django.core.exceptions import SuspiciousOperation
-from django.core.exceptions import ImproperlyConfigured
+from django.views.generic import ListView
 
 try:
     from django.contrib.gis.geos import Polygon
@@ -26,9 +25,9 @@ try:
 except (ImportError, ImproperlyConfigured):
     from .fields import PointField
 
+from . import GEOJSON_DEFAULT_SRID
 from .http import HttpGeoJSONResponse
 from .serializers import Serializer as GeoJSONSerializer
-from . import GEOJSON_DEFAULT_SRID
 
 
 class GeoJSONResponseMixin(object):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 from io import open
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -16,14 +17,14 @@ setup(
                      open(os.path.join(here, 'CHANGES'), encoding='utf-8').read(),
     license='LPGL, see LICENSE file.',
     install_requires=[
-        'Django>=3.2',
+        'Django>=4.0',
     ],
     extras_require={
         'field': ['django-leaflet>=0.12'],
         'docs': ['sphinx', 'sphinx-autobuild'],
     },
     packages=find_packages(),
-    python_requires=">=3.5",
+    python_requires=">=3.8",
     include_package_data=True,
     zip_safe=False,
     classifiers=['Topic :: Utilities',
@@ -33,9 +34,10 @@ setup(
                  'Environment :: Web Environment',
                  'Framework :: Django',
                  'Development Status :: 5 - Production/Stable',
-                 'Programming Language :: Python :: 3.5',
-                 'Programming Language :: Python :: 3.6',
-                 'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
+                 'Programming Language :: Python :: 3.9',
+                 'Programming Language :: Python :: 3.10',
+                 'Programming Language :: Python :: 3.11',
+                 'Programming Language :: Python :: 3.12',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,31 @@
 [tox]
 skipsdist = True
 envlist =
-    {py37}-django-{32}
-    {py38}-django-{32,40,41}
-    {py39}-django-{32,40,41}
-    {py310}-django-{32,40,41}
-    {py310}-isort
-    {py310}-flake8
+    flake8
+    isort
+    py38-django{40,41,42}
+    py39-django{40,41,42}
+    py310-django{40,41,42,50}
+    py311-django{41,42,50}
+    py312-django{42,50}
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
 deps =
-    flake8: flake8
-    django-32: Django>=3.2,<3.3
-    django-40: Django>=4.0,<4.1
-    django-41: Django>=4.1,<4.2
-    isort: isort
+    coverage
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
+    django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
 commands =
-    isort: isort .
-    flake8: flake8 --ignore=E501,W504 djgeojson
-    django: python -W error::DeprecationWarning -W error::PendingDeprecationWarning -W ignore:::site -W ignore:::distutils {toxinidir}/quicktest.py djgeojson
+    python \
+        -W error::DeprecationWarning \
+        -W error::PendingDeprecationWarning \
+        -W ignore:::site \
+        -W ignore:::distutils \
+        -m coverage run \
+        {toxinidir}/quicktest.py djgeojson
 
 [testenv:docs]
 basepython = python
@@ -28,9 +33,21 @@ changedir = docs
 deps =
     sphinx
     sphinx_rtd_theme
-    Django>=3.2,<4.1
+    Django>=5.0,<5.1
 commands =
     sphinx-build -W -b html -d build/doctrees . build/html
+
+[testenv:flake8]
+usedevelop = false
+basepython = python3.12
+deps = flake8
+commands = flake8 --ignore=E501,W504 djgeojson
+
+[testenv:isort]
+usedevelop = false
+basepython = python3.12
+deps = isort
+commands = isort .
 
 [isort]
 skip_gitignore = true


### PR DESCRIPTION
This PR:

1. Drops Python 3.7, since it is EOL.
2. Adds Python 3.11 and 3.12.
3. Drops Django 3.2. The Ubuntu CI environment uses SpatiaLite 5.0, but that is only supported by Django 4.0+, since [Ticket #32575](https://code.djangoproject.com/ticket/32575). It’s easiest to drop Django 3.2, which ends its long term support [this month](https://www.djangoproject.com/download/#supported-versions) anyway.
4. Adds Django 4.2 and 5.0. No code changes required.
5. Changes GitHub actions to run one task per Python version, running all Django versions underneath. That is faster and removes the need to duplicate test matrices between tox and GHA.
6. Upgrades GitHub Actions actions repositories.
7. Re-applies isort, which makes some changes from [version 5](https://pycqa.github.io/isort/docs/major_releases/introducing_isort_5.html), mostly due to working on all kinds of import blocks.
8. Adds a workaround for a bug when running SQLite 3.36+ with SpatiaLite 5 - see comment in `quicktest.py`.
9. Adjusts a test to pass with slightly altered values - I think caused by SpatiaLite 5, which [changed its topology library](https://groups.google.com/g/spatialite-users/c/MlXsPU0ZMYw/m/t-ynEJ2TBQAJ), among other things that may change calculations.