### PR TITLE
Remove Python 2 only code

### DIFF
--- a/djgeojson/fields.py
+++ b/djgeojson/fields.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.db.models import JSONField
 from django.forms.fields import JSONField as JSONFormField, InvalidJSONInput
 from django.forms.widgets import HiddenInput

--- a/djgeojson/nogeos.py
+++ b/djgeojson/nogeos.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 class GEOSGeometry(object):
     """
     A simple mock of django.contrib.gis.geos.GEOSGeometry to make

--- a/djgeojson/tests.py
+++ b/djgeojson/tests.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import json
 
 import django

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # django-geojson documentation build configuration file, created by
 # sphinx-quickstart on Tue Feb 28 13:44:49 2017.


### PR DESCRIPTION
* `__future__.unicode_literals` - no-op from Python 3.0 onwards: https://docs.python.org/3/library/__future__.html#module-contents
* `coding: utf-8` comments - Python 3 defaults to UTF-8: https://docs.python.org/3/howto/unicode.html#unicode-literals-in-python-source-code